### PR TITLE
Fix broken star history chart

### DIFF
--- a/Agent0/executor_train/README.md
+++ b/Agent0/executor_train/README.md
@@ -138,7 +138,7 @@ We thank [Netmind.AI](https://www.netmind.ai/), [SeaAI Lab](https://sail.sea.com
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=TIGER-AI-Lab/verl-tool&type=Date)](https://www.star-history.com/#TIGER-AI-Lab/verl-tool&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=TIGER-AI-Lab/verl-tool&type=Date)](https://star-history.dera.page/#TIGER-AI-Lab/verl-tool&Date)
 
 
 ## Badge

--- a/README.md
+++ b/README.md
@@ -224,4 +224,4 @@ We thank the open-source community for their foundational work that made this re
 - The VeRL team for their excellent RL framework
 - All the benchmark creators and maintainers
 
-[![✨Star History Chart](https://api.star-history.com/svg?repos=aiming-lab/Agent0&type=Date)](https://star-history.com/#bytebase/star-history&Date)
+[![✨Star History Chart](https://star-history.dera.page/svg?repos=aiming-lab/Agent0&type=Date)](https://star-history.dera.page/#aiming-lab/Agent0&Date)


### PR DESCRIPTION
The star history charts in the main README and the executor_train README are currently broken and no longer display. Update them to use a working star history service so the charts render correctly again for aiming-lab/Agent0 and TIGER-AI-Lab/verl-tool.